### PR TITLE
Make IntelliJ align method parameters correctly

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -88,6 +88,7 @@
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
       <option name="TAB_SIZE" value="8" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="CoffeeScript">

--- a/src/main/java/Example1.java
+++ b/src/main/java/Example1.java
@@ -63,6 +63,12 @@ public class Example1
     }
   }
 
+  public void multiLineMethod(MyReallyLongClassName foo, MyOtherReallyLongClassName bar,
+      MyOtherOtherReallyLongClassName zar)
+  {
+    //do stuff
+  }
+
   private class InnerClass
       implements I1, I2
   {


### PR DESCRIPTION
Without this long methods gets params aligned with args
