### PR TITLE
Prevent aligning of method params with multiline method signature

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -180,6 +180,7 @@
     <option name="WHILE_ON_NEW_LINE" value="true" />
     <option name="CATCH_ON_NEW_LINE" value="true" />
     <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />


### PR DESCRIPTION
Makes format conform to this style: https://github.com/sonatype/codestyle/blob/master/src/main/java/Example1.java#L67