### PR TITLE
Denote future bindable members

### DIFF
--- a/Frontend-Coding-Standards.md
+++ b/Frontend-Coding-Standards.md
@@ -120,6 +120,22 @@ At Sonatype we value the stability and maintainability of the code base while st
   }
 ```
 
+  * We denote future bindable members at the top of Angular controllers
+```javascript
+  function FooController() {
+    var vm = this;
+
+    vm.error = undefined;
+    vm.bar = Bar;
+    vm.foo = 'foo';
+
+    function Bar() {
+      /* code block */
+      vm.error = "error";
+    }
+  }
+```
+
 # Jasmine Development
 * Jasmine root describe should share the name of the containing file
   * This allows developers to easily locate code for failing tests

--- a/Frontend-Coding-Standards.md
+++ b/Frontend-Coding-Standards.md
@@ -103,6 +103,22 @@ At Sonatype we value the stability and maintainability of the code base while st
   }
   FooController.$inject = ['$state'];
 ```
+* We place bindable members on the top of Angular controllers
+  * We value digestable code that is easily accessible when reading the files
+  * We understand that this requires the (ab)use of Javascripts hoisting
+  * We believe that the advantages of clearly indicated bindable members outways the disadvantages of obscured code
+```javascript
+  function FooController() {
+    var vm = this;
+
+    vm.bar = Bar;
+    vm.foo = 'foo';
+
+    function Bar() {
+      /* code block */
+    }
+  }
+```
 
 # Jasmine Development
 * Jasmine root describe should share the name of the containing file


### PR DESCRIPTION
  * We denote future bindable members at the top of Angular controllers
```javascript
  function FooController() {
    var vm = this;

    vm.error = undefined;
    vm.bar = Bar;
    vm.foo = 'foo';

    function Bar() {
      /* code block */
      vm.error = "error";
    }
  }
```