### PR TITLE
Denote future bindable members

### DIFF
--- a/Kaos-Frontend-Coding-Standards.md
+++ b/Kaos-Frontend-Coding-Standards.md
@@ -136,6 +136,21 @@ At Sonatype we value the stability and maintainability of the code base while st
     }
   }
 ```
+* We denote future bindable members at the top of Angular controllers
+```javascript
+  function FooController() {
+    var vm = this;
+
+    vm.bar = Bar;
+    vm.error = undefined;
+    vm.foo = 'foo';
+
+    function Bar() {
+      /* code block */
+      vm.error = "error";
+    }
+  }
+```
 
 # Jasmine Development
 * Jasmine root describe should share the name of the containing file

--- a/Kaos-Frontend-Coding-Standards.md
+++ b/Kaos-Frontend-Coding-Standards.md
@@ -137,6 +137,7 @@ At Sonatype we value the stability and maintainability of the code base while st
   }
 ```
 * We denote future bindable members at the top of Angular controllers
+  * This allows developers to easily locate member variables that will be binded in the future
 ```javascript
   function FooController() {
     var vm = this;


### PR DESCRIPTION
As per our discussion [1], we will denote future bindable members as well. I'd like to get 2 +1's on wording, prior to integrating this. 

* We denote future bindable members at the top of Angular controllers
  * This allows developers to easily locate member variables that will be binded in the future
```javascript
  function FooController() {
    var vm = this;

    vm.bar = Bar;
    vm.error = undefined;
    vm.foo = 'foo';

    function Bar() {
      /* code block */
      vm.error = "error";
    }
  }
```

This PR replaces https://github.com/sonatype/codestyle/pull/8
[1]https://docs.google.com/spreadsheets/d/1eFKyXJsOPDrqxppQQXzwGpuG8CZV33h9OYu2M5GTPv0/edit#gid=0