### PR TITLE
Changed the Eclipse java formatter for method and constructor parameters to match the formatting used by the Nexus team

### DIFF
--- a/sonatype-eclipse.xml
+++ b/sonatype-eclipse.xml
@@ -99,7 +99,7 @@
 <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="82"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="next_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
@@ -246,7 +246,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="82"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
 <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>

--- a/src/main/java/Example1.java
+++ b/src/main/java/Example1.java
@@ -10,6 +10,16 @@ public class Example1
 
   public int[] X = new int[]{1, 3, 5, 7, 9, 11};
 
+  public Example1(boolean a, int x, int y, int z) throws IOException {
+  }
+
+  public Example1(MyReallyLongClassName foo,
+                  MyOtherReallyLongClassName bar,
+                  MyOtherOtherReallyLongClassName car,
+                  MyOtherOtherReallyLongClassName zar) throws IOException
+  {
+  }
+  
   public void foo(boolean a, int x, int y, int z) throws IOException {
     label1:
     do {
@@ -63,8 +73,9 @@ public class Example1
     }
   }
 
-  public void multiLineMethod(MyReallyLongClassName foo, MyOtherReallyLongClassName bar,
-      MyOtherOtherReallyLongClassName zar)
+  public void multiLineMethod(MyReallyLongClassName foo,
+                              MyOtherReallyLongClassName bar,
+                              MyOtherOtherReallyLongClassName zar) throws IOException
   {
     //do stuff
   }


### PR DESCRIPTION
Changes voted in the "Java method parameter formatting" email thread on Dec 4th, 2015. There were 5 votes for the Nexus style and 1.5 votes for the CLM style.