### PR TITLE
Fewer element queries during functional tests

### DIFF
--- a/Kaos-Frontend-Coding-Standards.md
+++ b/Kaos-Frontend-Coding-Standards.md
@@ -168,3 +168,7 @@ At Sonatype we value the stability and maintainability of the code base while st
 
 # Style guidelines
 * One-off styles should be referenced by ID and do not neeed a styleguide example
+
+# Selenide Development
+* Typically our page objects contain a root object, in cases where that root selector is known (i.e. #someid) we should use that in subqueries directly
+  * Replace root.$(".someclass") with $("#someid .someclass") to save roundtrips

--- a/Kaos-Frontend-Coding-Standards.md
+++ b/Kaos-Frontend-Coding-Standards.md
@@ -170,5 +170,5 @@ At Sonatype we value the stability and maintainability of the code base while st
 * One-off styles should be referenced by ID and do not neeed a styleguide example
 
 # Selenide Development
-* Typically our page objects contain a root object, in cases where that root selector is known (i.e. #someid) we should use that in subqueries directly
-  * Replace root.$(".someclass") with $("#someid .someclass") to save roundtrips
+* Typically our page objects contain a method for to retrieve a root object, in cases where that root selector is known (i.e. #someid) we should use that in subqueries directly
+  * Replace root().$(".someclass") with $("#someid .someclass") to save roundtrips

--- a/Kaos-Frontend-Coding-Standards.md
+++ b/Kaos-Frontend-Coding-Standards.md
@@ -170,5 +170,5 @@ At Sonatype we value the stability and maintainability of the code base while st
 * One-off styles should be referenced by ID and do not neeed a styleguide example
 
 # Selenide Development
-* Typically our page objects contain a method for to retrieve a root object, in cases where that root selector is known (i.e. #someid) we should use that in subqueries directly
+* Typically our page objects contain a method to retrieve a root object, in cases where that root selector is known (i.e. #someid) we should use that in subqueries directly
   * Replace root().$(".someclass") with $("#someid .someclass") to save roundtrips


### PR DESCRIPTION
Back in the groovy/geb/spock days, I recall it being good practice to do fewer queries to save time.

replacing ```root().$(".someclass");``` with ```$("#someid .someclass");``` where possible