### PR TITLE
Prevent import asterisks. Remove defaults for auto import asterisks.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -17,8 +17,11 @@
   <option name="GENERATE_FINAL_PARAMETERS" value="true" />
   <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false" />
   <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+  <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+    <value />
+  </option>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="java" withSubpackages="true" static="false" />


### PR DESCRIPTION
This came up in a PR [0] - the defaults for Eclipse vary from those for IDEA. These would adjust IDEA to be more in line with the Eclipse defaults.

[0] https://github.com/sonatype/application-health-check/issues/102