### PR TITLE
Align IDEA and Eclipse javascript codestyle flags for newline after [ and before ]

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -431,8 +431,6 @@
     <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
     <option name="IF_BRACE_FORCE" value="1" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="1" />


### PR DESCRIPTION
I opted to just change the IDEA side to match eclipse

```
var promises = [
  TagStore[vm.loadError ? 'refresh' : 'get'](), TagStore.getApplied(), ApplicationStore.get(),
  PolicyHierarchyStore.get(), PolicyTagStore.getApplied()
], policyMap = {};
```

is now

```
var promises = [TagStore[vm.loadError ? 'refresh' : 'get'](), TagStore.getApplied(), ApplicationStore.get(),
                PolicyHierarchyStore.get(), PolicyTagStore.getApplied()], policyMap = {};
```

Initially discussed here https://github.com/sonatype/insight-brain/pull/1804#discussion_r54445171
