### PR TITLE
Added IDEA rules for fixing spaces within array initializer braces and before array initializer left braces.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -184,6 +184,8 @@
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
     <option name="SPACE_WITHIN_BRACES" value="true" />
+    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="5" />
     <option name="EXTENDS_LIST_WRAP" value="1" />


### PR DESCRIPTION
These rules will fix array initializer spaces as in the following example:
 Before formatting:   String[] servers = new String[]{"server"};
 After formatting:     String[] servers = new String[] { "server" };
