### PR TITLE
Import ordering for javafx.* packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Order:
 
 * java
 * javax
+* javafx
 * com.sonatype
 * org.sonatype
 * _other_

--- a/sonatype-eclipse-imports.importorder
+++ b/sonatype-eclipse-imports.importorder
@@ -1,8 +1,9 @@
 #Organize Import Order
 #Tue Jun 11 12:45:09 EDT 2013
-5=\#
-4=
-3=org.sonatype
-2=com.sonatype
+6=\#
+5=
+4=org.sonatype
+3=com.sonatype
+2=javafx
 1=javax
 0=java

--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -25,6 +25,8 @@
       <emptyLine />
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
+      <package name="javafx" withSubpackages="true" static="false" />
+      <emptyLine />
       <package name="com.sonatype" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="org.sonatype" withSubpackages="true" static="false" />
@@ -82,6 +84,8 @@
         <package name="java" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javafx" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="com.sonatype" withSubpackages="true" static="false" />
         <emptyLine />


### PR DESCRIPTION
javafx.* imports currently end up in the "other" group, notably separated from other imports for JRE functionality. I propose to group them near the "java" and "javax" groups.