### PR TITLE
Fix issue 3. Do not wrap throws clause.

### DIFF
--- a/sonatype-eclipse.xml
+++ b/sonatype-eclipse.xml
@@ -33,8 +33,8 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="17"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>


### PR DESCRIPTION
[Description of issue 3](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+Eclipse+Java+Formatter#CodeStyleIssuesRelatedToTheEclipseJavaFormatter-issue3)

The fix is to tell Eclipse not to wrap the throws clause for constructor and method declarations.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/5412866/39004709-bea8f0a2-43c3-11e8-85ae-9836313df69c.png">
