### PR TITLE
Fix issue 5.  Do not preserve empty blank lines.

### DIFF
--- a/sonatype-eclipse.xml
+++ b/sonatype-eclipse.xml
@@ -290,7 +290,7 @@
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>


### PR DESCRIPTION
[Description of issue 5](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+Eclipse+Java+Formatter#CodeStyleIssuesRelatedToTheEclipseJavaFormatter-issue5)

The formatter should clean up existing empty lines that don't match the other rules for empty lines.

The change in the UI is:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/5412866/39006345-659a3b7e-43c8-11e8-85e5-0adbc6d24caa.png">
