### PR TITLE
IDEA Styling for HCL

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -97,6 +97,10 @@
       </value>
     </option>
   </GroovyCodeStyleSettings>
+  <HCL-Terraform>
+    <option name="PROPERTY_ALIGNMENT" value="2" />
+    <option name="ARRAY_WRAPPING" value="1" />
+  </HCL-Terraform>
   <JSCodeStyleSettings>
     <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
   </JSCodeStyleSettings>
@@ -489,4 +493,3 @@
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>
-


### PR DESCRIPTION
This update adds styling rules for HCL. 

- Property alignment will be set to align on the equal sign.
- Array wrapping will only be done for long arrays.

All other defaults are left in tact.  This matches the formatting that's somewhat standard in the terraform community and prevalent in examples throughout the Terraform docs.