### PR TITLE
Converted the PMD ruleset to be compatible with pmd-maven-plugin 3.9 and newer

### DIFF
--- a/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
+++ b/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
@@ -10,7 +10,7 @@
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <description>PMD ruleset originally created for insight-brain</description>
+  <description>PMD ruleset to be used with maven-pmd-plugin 3.9 or newer.</description>
 
   <!-- Unused code -->
   <rule ref="category/java/bestpractices.xml/UnusedImports" />

--- a/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
+++ b/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
@@ -12,13 +12,19 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
   <description>PMD ruleset originally created for insight-brain</description>
 
-  <rule ref="rulesets/java/unusedcode.xml">
-    <!-- This rule appears to be flaky and tends to give false positives involving static methods -->
-    <exclude name="UnusedPrivateMethod"/>
-  </rule>
-  <rule ref="rulesets/java/imports.xml">
-    <exclude name="TooManyStaticImports"/>
-    <exclude name="UnnecessaryFullyQualifiedName"/>
-  </rule>
-  <rule ref="rulesets/java/braces.xml"/>
+  <!-- Unused code -->
+  <rule ref="category/java/bestpractices.xml/UnusedImports" />
+  <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+  <!-- This rule appears to be flaky and tends to give false positives involving static methods
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" /> -->
+
+  <!-- Imports -->
+  <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
+  <rule ref="category/java/codestyle.xml/DuplicateImports" />
+  <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
+
+  <!-- Braces -->
+  <rule ref="category/java/codestyle.xml/ControlStatementBraces" />
 </ruleset>


### PR DESCRIPTION
From the pmd-maven-plugin documentation [0]:
"Starting with PMD 6.0.0 and Maven PMD Plugin 3.9.0, the rules have been reorganized into categories, e.g. /category/java/bestpractices.xml. So when upgrading to Maven PMD Plugin 3.9.0 you should review your plugin configuration and/or custom ruleset."

[0] https://maven.apache.org/plugins/maven-pmd-plugin/examples/usingRuleSets.html
