### PR TITLE
Fix IDEA Formatter Issues 1, 5, 6.  Fix blank link issues.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -195,6 +195,9 @@
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="IF_BRACE_FORCE" value="3" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
     <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />

--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -195,7 +195,7 @@
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="IF_BRACE_FORCE" value="3" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />


### PR DESCRIPTION
[Description of issue 1](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue1)
[Description of issue 5](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue5)
[Description of issue 6](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue6)

This makes the IDEA formatter consistent with the Eclipse formatter for blank lines, with the exception of blank lines after class declarations which Eclipse does not have a fix for (issue 5)

<img width="429" alt="image" src="https://user-images.githubusercontent.com/5412866/47859149-a617ca80-ddbb-11e8-8259-61fbb69da376.png">
  