### PR TITLE
Fix IDEA Formatter Issue 2.  Add wrapping for long assignments.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -179,6 +179,7 @@
     <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
     <option name="ASSERT_STATEMENT_COLON_ON_NEXT_LINE" value="true" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
     <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="BLANK_LINES_AROUND_FIELD" value="1" />
     <option name="BLANK_LINES_AROUND_FIELD_IN_INTERFACE" value="1" />

--- a/src/main/java/Example1.java
+++ b/src/main/java/Example1.java
@@ -12,6 +12,9 @@ public class Example1
 
   public static final int[] X = new int[]{1, 3, 5, 7, 9, 11};
 
+  public static final MyReallyLongClassName THE_REALLY_LONG_VARIABLE_NAME_FOR_THE_REALLY_LONG_CLASS_NAME =
+      new MyReallyLongClassName("foo");
+
   public Example1(boolean a, int x, int y, int z) throws IOException {
   }
 


### PR DESCRIPTION
[Description of the issue](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue2)

Wraps really long assignments.  Is related to https://github.com/sonatype/codestyle/pull/39, which is the fix for Eclipse.

Add the code example, @vladt asked for on the Eclipse PR.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/5412866/47820045-4c1af480-dd2a-11e8-9a25-f2465ee03617.png">
