### PR TITLE
Fix IDEA Formatter Issue 4. Indent Javadoc line continuation.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -41,6 +41,7 @@
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
   <option name="JD_KEEP_EMPTY_RETURN" value="false" />
   <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
+  <option name="JD_INDENT_ON_CONTINUATION" value="true" />
   <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
   <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
   <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />


### PR DESCRIPTION
[Description of the issue](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue4)

<img width="484" alt="image" src="https://user-images.githubusercontent.com/5412866/47856869-3b17c500-ddb6-11e8-975a-2e289f7345b1.png">

Note that the behaviour is not exactly the same as Eclipse. 

<img width="635" alt="image" src="https://user-images.githubusercontent.com/5412866/47856919-57b3fd00-ddb6-11e8-990b-9dd49b6fe42a.png">

It indents by 4 rather than aligning with the @symbol Also, IDEA has officially moved these settings elsewhere https://confluence.jetbrains.com/display/IDEADEV/New+project+code+style+settings+format+in+2017.3 but importing this file will move them to the correct location.

After importing, I get something like:

```xml
  <JavaCodeStyleSettings>
    <option name="GENERATE_FINAL_PARAMETERS" value="true" />
    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
    <option name="IMPORT_LAYOUT_TABLE">
      <value>
        <package name="java" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="javax" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="javafx" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="com.sonatype" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="org.sonatype" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="" withSubpackages="true" static="false" />
        <emptyLine />
        <package name="" withSubpackages="true" static="true" />
      </value>
    </option>
    <option name="JD_P_AT_EMPTY_LINES" value="false" />
    <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
    <option name="JD_KEEP_EMPTY_RETURN" value="false" />
    <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
    <option name="JD_INDENT_ON_CONTINUATION" value="true" />
  </JavaCodeStyleSettings>
```