### PR TITLE
Fix IDEAA Formatter Issue 7. 'Next line if wrap' for braces.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -184,6 +184,7 @@
     <option name="BLANK_LINES_AROUND_FIELD_IN_INTERFACE" value="1" />
     <option name="BLANK_LINES_BEFORE_PACKAGE" value="0" />
     <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="BRACE_STYLE" value="5" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="CATCH_ON_NEW_LINE" value="true" />
     <option name="CLASS_BRACE_STYLE" value="2" />


### PR DESCRIPTION
[Description of the issue](https://docs.sonatype.com/display/~tneeriemer/Code+Style+Issues+Related+To+The+IntelliJ+IDEA+Java+Formatter#CodeStyleIssuesRelatedToTheIntelliJIDEAJavaFormatter-issue7)

This will move the brace correctly to the next line.  Note that there is not a fix for this issue in the Eclipse formatter.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/5412866/47859979-7ec1fd00-ddbd-11e8-9150-e5a99326febf.png">
