### PR TITLE
Tweak LeftCurly rules to more closely match our style.

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -45,11 +45,11 @@
     </module>
     <module name="LeftCurly">
       <property name="option" value="nlow"/>
-      <property name="tokens" value="ANNOTATION_DEF, CTOR_DEF, METHOD_DEF, LITERAL_WHILE, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, STATIC_INIT, OBJBLOCK"/>
+      <property name="tokens" value="CTOR_DEF, METHOD_DEF, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, STATIC_INIT, OBJBLOCK"/>
     </module>
     <module name="LeftCurly">
       <property name="option" value="nl"/>
-      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ENUM_CONSTANT_DEF"/>
+      <property name="tokens" value="ANNOTATION_DEF, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ENUM_CONSTANT_DEF"/>
     </module>
     <module name="RightCurly">
       <property name="option" value="alone"/>


### PR DESCRIPTION
While updating some of the Insight code to be compliant with the Checkstyle rules it became clear that some of the rules where not correct.

As a general rule, left curly braces should be at the [end of the line](https://github.com/sonatype/codestyle/blob/907307cba52a961720030c08979439869c1bbd0f/src/main/java/Example1.java#L51), with a couple of exceptions. Type definitions should have the left curly brace on a [new line](https://github.com/sonatype/codestyle/blob/907307cba52a961720030c08979439869c1bbd0f/src/main/java/Example1.java#L8) and wrapped constructor and method definition (and try/catch blocks) should have a [new line when wrapped but otherwise at the end of the line](https://github.com/sonatype/codestyle/blob/907307cba52a961720030c08979439869c1bbd0f/src/main/java/Example1.java#L22).  

This change effectively removes if, while and for statements from the "new line on wrap" config and requires those left curly braces to be on the same line.   This change puts the rules in sync with the current Eclipse and Intellij formatters.  It also treats annotation definitions as a type definition.

This change reduced the violations for LeftCurly in the insight-brain project from 170 to 93 and a spot check of the remaining 93 seemed to be correct violations.  A scan of the Nexus code base also showed fewer LeftCurly violations after the change.

The previous settings were causing examples such as these to fail:

https://github.com/sonatype/insight-clm-dto-model/blob/a4123b9d99600a8e5781d926643958bfb586ceff/com.sonatype.clm.dto.model/src/main/java/com/sonatype/clm/dto/model/policy/Stage.java#L66

https://github.com/sonatype/insight-brain/blob/5c41cbe68c3b8ab0c7d9df721f62e36ab08362a5/insight-brain-service/src/main/java/com/sonatype/insight/brain/security/AuthzContext.java#L28

https://github.com/sonatype/insight-brain/blob/5c41cbe68c3b8ab0c7d9df721f62e36ab08362a5/insight-brain-service/src/main/java/com/sonatype/insight/brain/api/v2/service/ApiComponentEvaluationServiceV2.java#L250

Docs on the LeftCurly rule are at http://checkstyle.sourceforge.net/config_blocks.html#LeftCurly


