### PR TITLE
Remove rule for javadoc indentation that does not enforce our actual practices.

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -148,9 +148,6 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="NonEmptyAtclauseDescription"/>
-    <module name="JavadocTagContinuationIndentation">
-      <property name="offset" value="2"/>
-    </module>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>


### PR DESCRIPTION
Not sure why this rule was even added.   Our examples don't include additional indentation.

Some places that were in violation of this rule include:

https://github.com/sonatype/nexus-internal/blob/c2261683ac73f83efc62bf321c9143c9f9662525/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/HttpClientManager.java#L56

https://github.com/sonatype/insight-clm-dto-model/blob/a4123b9d99600a8e5781d926643958bfb586ceff/com.sonatype.clm.dto.model/src/main/java/com/sonatype/clm/dto/model/ide/IdeMatchedComponent.java#L24

Removing the rule also means that the code formatters do not need to be changed to accommodate the rule.