### PR TITLE
Update Intellij/Eclipse code formatters to consistently wrap long annotation params (and an intellij blank line fix)

### DIFF
--- a/sonatype-eclipse.xml
+++ b/sonatype-eclipse.xml
@@ -10,7 +10,7 @@
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
 <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>

--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -74,6 +74,9 @@
   <option name="WHILE_BRACE_FORCE" value="1" />
   <option name="FOR_BRACE_FORCE" value="1" />
   <option name="ENUM_CONSTANTS_WRAP" value="2" />
+  <JavaCodeStyleSettings>
+    <option name="ANNOTATION_PARAMETER_WRAP" value="5" />
+  </JavaCodeStyleSettings>
   <GroovyCodeStyleSettings>
     <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false" />
     <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
@@ -198,7 +201,7 @@
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
     <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />


### PR DESCRIPTION
`KEEP_BLANK_LINES_BEFORE_RBRACE=1` was inserting a blank line before the end of the class and angering checkstyle.

---


The `ANNOTATION_PARAMETER_WRAP` fixes the following issue:
![screen shot 2019-02-07 at 4 51 04 pm](https://user-images.githubusercontent.com/131809/52515382-c3450c00-2be8-11e9-85f3-57e6109eceb4.png)
 (checkstyle error = `'}' have incorrect indentation level 2, expected level should be 6.`).

This is the equivalent of setting `Wrapping and Braces` -> `Annotation parameters` to `Chop down if long` (from the default value of `Do not wrap`)

New format below: 
![screen shot 2019-02-08 at 9 33 15 pm](https://user-images.githubusercontent.com/131809/52515419-47978f00-2be9-11e9-8706-c5113ab2dd33.png)
