### PR TITLE
Update checkstyle configuration to match intellij/eclipse behavior w…

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -44,8 +44,12 @@
       <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
     <module name="LeftCurly">
+      <property name="option" value="eol"/>
+      <property name="tokens" value="LITERAL_TRY"/>
+    </module>
+    <module name="LeftCurly">
       <property name="option" value="nlow"/>
-      <property name="tokens" value="CTOR_DEF, METHOD_DEF, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, STATIC_INIT, OBJBLOCK"/>
+      <property name="tokens" value="CTOR_DEF, METHOD_DEF, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, STATIC_INIT, OBJBLOCK"/>
     </module>
     <module name="LeftCurly">
       <property name="option" value="nl"/>

--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -44,10 +44,6 @@
       <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
     <module name="LeftCurly">
-      <property name="option" value="eol"/>
-      <property name="tokens" value="LITERAL_TRY"/>
-    </module>
-    <module name="LeftCurly">
       <property name="option" value="nlow"/>
       <property name="tokens" value="CTOR_DEF, METHOD_DEF, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, STATIC_INIT, OBJBLOCK"/>
     </module>


### PR DESCRIPTION
…hen a try-with-resources with multiple declarations is encountered.


Intellij and Eclipse currently both format a try with resources that declares multiple variables like this: 

![screen shot 2019-02-11 at 12 02 08 pm](https://user-images.githubusercontent.com/131809/52584777-ffeb5000-2e00-11e9-821b-f785ec3eca05.png)

The current Checkstyle rules don't like that, and would prefer to see the opening brace on the next line.

This change makes a minimal change to the Checkstyle rules to match the current Intellij/Eclipse behavior.