### PR TITLE
Allow catch parameter name to include numbers

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -102,6 +102,7 @@
                value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
+      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
       <message key="name.invalidPattern"
                value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
Checkstyle issue I came across, it currently doesn't allow `e1` and `e2`  in the following

https://github.com/sonatype/insight-brain/blob/def472f127b9cd63b0c2920415c44a7b84621e0f/insight-brain-service/src/main/java/com/sonatype/insight/brain/product/license/CLMLicenseManager.java#L337-L344

(default regex is `^(e|t|ex|[a-z][a-z][a-zA-Z]+)$` http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.html)

Gut reaction is this should be ok though, this would fix it if we agree