### PR TITLE
Wrap all Java params on lines that get over the length limit (120)

### DIFF
--- a/sonatype-eclipse.xml
+++ b/sonatype-eclipse.xml
@@ -26,8 +26,8 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="82"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="82"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="33"/>

--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -58,6 +58,7 @@
   <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
   <option name="METHOD_PARAMETERS_WRAP" value="1" />
+  <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
   <option name="EXTENDS_LIST_WRAP" value="1" />
   <option name="THROWS_LIST_WRAP" value="1" />
   <option name="EXTENDS_KEYWORD_WRAP" value="2" />


### PR DESCRIPTION
This changes the Java parameter wrapping to wrap all parameters when the method/constructor declaration is over the line length limit (120). Method/constructor declarations that fit on one line are not wrapped.

Eclipse:
![image](https://user-images.githubusercontent.com/239673/52812236-011cb700-3065-11e9-8db5-685579a4ca59.png)

Idea:
![image](https://user-images.githubusercontent.com/239673/52812393-55c03200-3065-11e9-83b4-cb93c66919fc.png)
