### PR TITLE
Wrap all Java params on lines that get over the length limit (120)

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -209,6 +209,7 @@
     <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="METHOD_BRACE_STYLE" value="5" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_WRAP" value="5" />
     <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />


### PR DESCRIPTION
Follow-up to https://github.com/sonatype/codestyle/pull/58

Noticed that this was no longer being applied in idea 2019.1. Not entirely sure what changed to stop it working but this fixes it for me. Leaving the duplicate line in (in case it's needed for older versions)

![Capture](https://user-images.githubusercontent.com/6968527/57542589-07f85480-734a-11e9-9658-00cfcac7b0e2.PNG)
