### PR TITLE
Update Checkstyle and associated rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ configuration for import handling, etc which is not ideal.
 It should be possible to craft separate configurations which are _mostly_ compatible and thus avoid _most_ noise if
 reformatting is done in a sane manner.
 
-**DO NOT** reformat entire codebases, but reformat as sources are touched to normalize.   Or normalize and _santizie_
+**DO NOT** reformat entire codebases, but reformat as sources are touched to normalize.   Or normalize and _sanitize_
 one by one, as the code formatters (IDEA or Eclipse) tend to create some formats which can and **SHOULD** be manually
 cleaned up, else the code will end up **LESS** readable.
 
@@ -187,7 +187,7 @@ Checkstyle
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.2</version>
         <configuration>
           <consoleOutput>true</consoleOutput>
           <configLocation>sonatype/checkstyle-configuration.xml</configLocation>
@@ -202,9 +202,14 @@ Checkstyle
         </executions>
         <dependencies>
           <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.42</version>
+          </dependency>
+          <dependency>
             <groupId>com.sonatype</groupId>
             <artifactId>checkstyle-checks</artifactId>
-            <version>8</version>
+            <version>15</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ See [the Intellij documentation](https://www.jetbrains.com/help/idea/copying-cod
 See [the eclipse documentation](http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-formatter.htm) for how to import the files into your IDE.
 In addition, html indentation settings are not exported, but can be set to 2 spaces from Preferences -> Web -> HTML Files -> Editor -> "Indent using spaces". [Screenshot of the eclipse config here.](https://s3.amazonaws.com/uploads.hipchat.com/18157/88592/RSkQhq8UYnxf81Z/upload.png)
 
-Note that Eclipse's _Organize Imports_ feature does not group imports by 1st party, 3rd party, etc. as defined by Checkstyle rules.
-
 ### Visual Studio
 
 Import sonatype-visualstudio-settings.xml using Tools -> Import and Export Settings...

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See [the Intellij documentation](https://www.jetbrains.com/help/idea/copying-cod
 See [the eclipse documentation](http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-formatter.htm) for how to import the files into your IDE.
 In addition, html indentation settings are not exported, but can be set to 2 spaces from Preferences -> Web -> HTML Files -> Editor -> "Indent using spaces". [Screenshot of the eclipse config here.](https://s3.amazonaws.com/uploads.hipchat.com/18157/88592/RSkQhq8UYnxf81Z/upload.png)
 
+Note that Eclipse's _Organize Imports_ feature does not group imports by 1st party, 3rd party, etc. as defined by Checkstyle rules.
+
 ### Visual Studio
 
 Import sonatype-visualstudio-settings.xml using Tools -> Import and Export Settings...

--- a/checkstyle-checks/pom.xml
+++ b/checkstyle-checks/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <checkstyle.version>8.29</checkstyle.version>
+    <checkstyle.version>8.42</checkstyle.version>
   </properties>
 
   <dependencies>

--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -136,11 +136,6 @@
       <property name="lineWrappingIndentation" value="4"/>
       <property name="arrayInitIndent" value="2"/>
     </module>
-    <module name="CustomImportOrder">
-      <property name="separateLineBetweenGroups" value="true"/>
-      <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STATIC"/>
-      <property name="specialImportsRegExp" value="^(com|org)\.sonatype\..*$"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="AnnotationLocation">
       <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>

--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -22,6 +22,12 @@
 
   <module name="SuppressWarningsFilter" />
 
+  <module name="LineLength">
+    <property name="max" value="120"/>
+    <!-- Allow longer lines in comments. -->
+    <property name="ignorePattern" value="^ \*.*"/>
+  </module>
+
   <module name="TreeWalker">
     <module name="com.sonatype.checks.ClassStructureEmptyLineCheck" />
     <module name="SuppressWarningsHolder" />
@@ -32,11 +38,6 @@
       <property name="tokens" value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="OuterTypeFilename"/>
-    <module name="LineLength">
-      <property name="max" value="120"/>
-      <!-- Allow longer lines in comments. -->
-      <property name="ignorePattern" value="^ \*.*"/>
-    </module>
     <module name="UnusedImports"/>
     <module name="NoLineWrap"/>
     <module name="EmptyBlock">
@@ -149,13 +150,9 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowMissingJavadoc" value="true"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.2</version>
         <dependencies>
           <dependency>
             <groupId>com.sonatype</groupId>

--- a/sonatype-eclipse-imports.importorder
+++ b/sonatype-eclipse-imports.importorder
@@ -1,9 +1,8 @@
 #Organize Import Order
 #Tue Jun 11 12:45:09 EDT 2013
-6=\#
-5=
-4=org.sonatype
-3=com.sonatype
-2=javafx
+5=\#
+4=
+3=org.sonatype
+2=com.sonatype
 1=javax
 0=java

--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -22,13 +22,9 @@
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
-      <package name="javafx" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="com.sonatype" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="org.sonatype" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />
@@ -86,13 +82,9 @@
     <option name="IMPORT_LAYOUT_TABLE">
       <value>
         <package name="java" withSubpackages="true" static="false" />
-        <emptyLine />
         <package name="javax" withSubpackages="true" static="false" />
         <emptyLine />
-        <package name="javafx" withSubpackages="true" static="false" />
-        <emptyLine />
         <package name="com.sonatype" withSubpackages="true" static="false" />
-        <emptyLine />
         <package name="org.sonatype" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="" withSubpackages="true" static="false" />

--- a/src/main/java/Imports.java
+++ b/src/main/java/Imports.java
@@ -1,6 +1,5 @@
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.crypto.NullCipher;
 
 import static java.lang.Math.min;


### PR DESCRIPTION
Our version of Checkstyle is out of date, does not enforce certain rules very well, and completely chokes on newer language elements such as switch expressions.

Unfortunately, that project uses [sentimental versioning](http://sentimentalversioning.org/) and broke some things without any clear migration guides :unamused: 

## Config changes that don't change behavior

The LineLength check only moved from one place to another

Javadoc `allowMissingThrowsTags` and `allowThrowsTagsForSubclasses` are [no longer supported](https://github.com/checkstyle/checkstyle/issues/7329).  Since we allowed these, it should be no change.

Javadoc `allowMissingJavadoc` and `minLineCount` moved to a new check.  Since we allow missing, I have not added that check.

Javadoc `scope` apparently got renamed to `accessModifiers`

## Unchanged config that changes behavior

Mainly I would highlight **import groups**.  Checkstyle defines a fixed number of logical groups to be separated by a blank line; we have
1. Standard (defined as java & javax)
2. 1st party (defined as org.sonatype & com.sonatype)
3. 3rd party (everything else)
4. static

It enforces that there are blank lines between those groups and no additional blank lines within groups, whereas it used to permit extra blank lines.  IMHO, this way of grouping and avoiding excess blank lines is good style and consistent with the existing rule, so I updated the IDEA config to be consistent.  _Unfortunately_, Eclipse only groups packages, so its auto-organize import feature is fundamentally different.
_EDIT: so I removed this check_

Related to this, `javax` left the JDK in version 11, so whether it is 3rd party or standard is not a matter of style but JDK version.  I updated the IDE configs to treat it as 3rd party, since that is current and consistent with Checkstyle.

The rule against unnecessary parentheses is enforced more rigidly now, and I had one or two other new violations with HDS, which seemed consistent with the existing rules.

Copied from https://github.com/sonatype/codestyle/pull/71