### PR TITLE
Update license text and Jenkins settings for OSS/public project.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 def settings = [
   javaVersion: 'Java 8',
   mavenVersion: 'Maven 3.2.x',
-  usePublicSettingsXmlFile: false,
+  usePublicSettingsXmlFile: true,
   useEventSpy: false,
   testResults: ['**/target/*-reports/*.xml'],
   distFiles: [

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 # Sonatype Codestyle

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,11 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
-
 # Reporting Security Vulnerabilities
 
 ## When to report

--- a/checkstyle-checks/pom.xml
+++ b/checkstyle-checks/pom.xml
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/checkstyle-checks/src/main/java/com/sonatype/checks/ClassStructureEmptyLineCheck.java
+++ b/checkstyle-checks/src/main/java/com/sonatype/checks/ClassStructureEmptyLineCheck.java
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 package com.sonatype.checks;
 

--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 <!DOCTYPE module PUBLIC

--- a/checkstyle-checks/src/test/java/com/sonatype/checks/ClassStructureEmptyLineCheckTest.java
+++ b/checkstyle-checks/src/test/java/com/sonatype/checks/ClassStructureEmptyLineCheckTest.java
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 package com.sonatype.checks;
 

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLineClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLineClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has trailing and preceeding empty lines

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLineInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLineInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has trailing and preceeding empty lines

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLinesClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLinesClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has multiple trailing and preceeding empty lines

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLinesInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyLinesInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has multiple trailing and preceeding empty lines

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyMinimalClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/bothEmptyMinimalClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 public class App

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodButEmptyClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodButEmptyClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 public class App {}

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 public class App

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 public interface Good

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodMultipleClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/goodMultipleClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 public class App

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLineClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLineClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has empty line preceding final right curly brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLineInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLineInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has empty line preceding final right curly brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLinesClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLinesClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has multiple empty lines preceding final right curly brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLinesInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/precedingEmptyLinesInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // has multiple empty lines preceding final right curly brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLineClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLineClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // Has an empty line trailing the opening brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLineInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLineInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // Has an empty line trailing the opening brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLinesClassSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLinesClassSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // Has multiple empty lines trailing the opening brace

--- a/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLinesInterfaceSource.java
+++ b/checkstyle-checks/src/test/resources/ClassStructureEmptyLineCheckTest/trailingEmptyLinesInterfaceSource.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
- * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
- * "Sonatype" is a trademark of Sonatype, Inc.
+ * Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
 package com.sonatype;
 
 // Has multiple empty lines trailing the opening brace

--- a/header.txt
+++ b/header.txt
@@ -1,3 +1,4 @@
-Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-"Sonatype" is a trademark of Sonatype, Inc.
+Copyright (c) ${project.inceptionYear}-present Sonatype, Inc. All rights reserved.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/.

--- a/java-scala-diff.md
+++ b/java-scala-diff.md
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 ### Some differences between Java and Scala styles

--- a/pmd-ruleset/pom.xml
+++ b/pmd-ruleset/pom.xml
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
+++ b/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 <ruleset name="sonatype ruleset"

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,9 @@
 <!--
 
-    Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
-    Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
-    "Sonatype" is a trademark of Sonatype, Inc.
+    Copyright (c) 2007-present Sonatype, Inc. All rights reserved.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
This is an open source project. Use the correct license headers and Jenkins settings.


Working build at https://jenkins.ci.sonatype.dev/job/bnr/job/tools/job/codestyle/job/feature-snapshots/job/publicSettings/

I discovered this while trying to enable checkstyle on https://github.com/sonatype/sonatype-application-builder which is also a public project.