### PR TITLE
Add Kotlin code style to idea

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -74,6 +74,9 @@
   <JavaCodeStyleSettings>
     <option name="ANNOTATION_PARAMETER_WRAP" value="5" />
   </JavaCodeStyleSettings>
+  <JetCodeStyleSettings>
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+  </JetCodeStyleSettings>
   <GroovyCodeStyleSettings>
     <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false" />
     <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
@@ -462,6 +465,20 @@
   <codeStyleSettings language="XML">
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="8" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="kotlin">
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
+    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
       <option name="TAB_SIZE" value="8" />
     </indentOptions>


### PR DESCRIPTION
https://issues.sonatype.org/browse/LIFT-2354

Adds Kotlin to Soantype Idea config. Obviously Kotlin is produced by Jetbrains and designed to work in IntelliJ. Nothing is really needed out of the box **except** for a desire to keep with the Sonatype indent of 2 instead of the Kotlin default of 4.

This change was produced by:
* Applying the Kotlin/IntelliJ defaults to the Kotlin 'Code style' option in the IDE. This would be the default but I wanted to be sure. https://kotlinlang.org/docs/code-style-migration-guide.html#migration-to-a-new-code-style
* Changed 'Indent' to 2, and 'Continuation Indent' to 4 to match Sonatype style
* Exported the scheme
* Manually sorted the options under `<codeStyleSettings language="kotlin">`