### PR TITLE
Kotlin was still using start imports on java.utils. Disable all of it.

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -78,6 +78,9 @@
     <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+      <value />
+    </option>
   </JetCodeStyleSettings>
   <GroovyCodeStyleSettings>
     <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false" />


### PR DESCRIPTION
This was accomplished from removing everything from the "Packages to use Import with '*'" list. In the default list are `java.util`, `io.ktor` and `kotlinx.android.synthetic`