### PR TITLE
Use UnnecessaryImport to support PMD 6.34+

### DIFF
--- a/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
+++ b/pmd-ruleset/src/main/resources/pmd-ruleset/ruleset.xml
@@ -14,7 +14,6 @@
   <description>PMD ruleset to be used with maven-pmd-plugin 3.9 or newer.</description>
 
   <!-- Unused code -->
-  <rule ref="category/java/bestpractices.xml/UnusedImports" />
   <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
   <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
@@ -22,9 +21,7 @@
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" /> -->
 
   <!-- Imports -->
-  <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
-  <rule ref="category/java/codestyle.xml/DuplicateImports" />
-  <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
+  <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
 
   <!-- Braces -->
   <rule ref="category/java/codestyle.xml/ControlStatementBraces" />


### PR DESCRIPTION
I'd like to use `UnnecessaryImport` to replace deprecated `UnusedImports`, `DontImportJavaLang`, `DuplicateImports` and `ImportFromSamePackage` for the next `pmd-ruleset` release to support PMD `6.34+`. 
HDS uses `maven-pmd-plugin` [3.20.0](https://github.com/sonatype/hosted-data-services/blob/46c450c22701c5ccd6885ccc03f4cb8f0e0ed90f/pom.xml#L1182) which depends on [PMD 6.53.0](https://maven.apache.org/plugins/maven-pmd-plugin/examples/upgrading-PMD-at-runtime.html). The [HDS Jenkins job](https://jenkins.ci.sonatype.dev/job/insight/job/hosted-data-services/view/Build/job/master-snapshot/4943/console) prints a lot of warning messages like:
```
[WARNING] Discontinue using Rule name category/java/bestpractices.xml/UnusedImports as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule.
[WARNING] Discontinue using Rule name category/java/codestyle.xml/DontImportJavaLang as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule.
```
p.s. The `maven-pmd-plugin` [always warns about deprecated rules](https://github.com/apache/maven-pmd-plugin/blob/931a292c906900d87d9f1de53469787ccb339c80/src/main/java/org/apache/maven/plugins/pmd/exec/PmdExecutor.java#L285-L286). This can't be configured from the maven plugin side.