### PR TITLE
Don't star import classes

### DIFF
--- a/sonatype-idea.xml
+++ b/sonatype-idea.xml
@@ -72,6 +72,8 @@
   <option name="FOR_BRACE_FORCE" value="1" />
   <option name="ENUM_CONSTANTS_WRAP" value="2" />
   <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     <option name="ANNOTATION_PARAMETER_WRAP" value="5" />
   </JavaCodeStyleSettings>
   <GroovyCodeStyleSettings>


### PR DESCRIPTION
I noticed my idea started start-importing classes. Looks like we need to set the  "Names count to use static import with '*'" to a higher value to avoid star imports when using a bunch of static imports (ie constants). While I was in there I also set "Class count to use import with '*'" to use a higher value.