### PR TITLE
Include jakarta package in Eclipse import order

### DIFF
--- a/sonatype-eclipse-imports.importorder
+++ b/sonatype-eclipse-imports.importorder
@@ -1,8 +1,9 @@
 #Organize Import Order
 #Tue Jun 11 12:45:09 EDT 2013
-5=\#
-4=
-3=org.sonatype
-2=com.sonatype
+6=\#
+5=
+4=org.sonatype
+3=com.sonatype
+2=jakarta
 1=javax
 0=java


### PR DESCRIPTION
It occurred to me that perhaps the jakarta packages ought to be placed above the javax packages.