### PR TITLE
CLM-31035: Remove UnnecessaryParentheses Rule

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -32,7 +32,6 @@
   <module name="TreeWalker">
     <module name="com.sonatype.checks.ClassStructureEmptyLineCheck" />
     <module name="SuppressWarningsHolder" />
-    <module name="UnnecessaryParentheses"/>
     <module name="EmptyLineSeparator">
       <property name="allowMultipleEmptyLines" value="false" />
       <property name="allowMultipleEmptyLinesInsideClassMembers" value="false" />


### PR DESCRIPTION
This is causing a lot of churn on insight-brain when upgrading. It seems to be catching more cases than it used to in earliery versions of checkstyle. The team does not feel this rule is of value, 90% of the cases it is catching are fealt by the team to be more readable as is

Passing Build: https://jenkins.ci.sonatype.dev/job/bnr/job/tools/job/codestyle/job/feature-snapshots/job/CLM-31035-Remove-Unnecessary-Paren-Check/1/

Jira Link: https://sonatype.atlassian.net/browse/CLM-31035