### PR TITLE
i-day: allow long package and import lines

### DIFF
--- a/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
+++ b/checkstyle-checks/src/main/resources/sonatype/checkstyle-configuration.xml
@@ -25,8 +25,14 @@
 
   <module name="LineLength">
     <property name="max" value="120"/>
-    <!-- Allow longer lines in block comments and whole string literals -->
-    <property name="ignorePattern" value='^ +\*|"[^"]{100,}"'/>
+    <!--
+        Allow longer lines in:
+        - package statements
+        - import statements
+        - block comments
+        - whole string literals
+    -->
+    <property name="ignorePattern" value='^package |^import |^ +\*|"[^"]{100,}"'/>
   </module>
 
   <module name="TreeWalker">


### PR DESCRIPTION
Long package and import lines are allowed by default until you start overriding the pattern. This brings back those patterns in addition to those we have. imports and package statements don't have a place to more locally suppress the checks, so when this popped, we ended up needing to suppress LineLength for the entire project. 😞 

I tested it by removing a global LineLength suppression from https://github.com/sonatype/ml-ingest/.